### PR TITLE
[develop] cd 워크플로 실행 시 npm과 pm2를 찾지 못하는 에러 해결

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -24,6 +24,8 @@ jobs:
           script: |
             cd ~/HoYo.gg
             git pull origin main
+            export NVM_DIR=~/.nvm
+            source ~/.nvm/nvm.sh
             npm ci
             npm run build
             pm2 gracefulReload hoyogg


### PR DESCRIPTION
#4 작업 이후 main 브랜치 push 테스트 결과 npm과 pm2 명령어를 찾지 못해 실패하는 것을 확인.

<img width="1099" alt="스크린샷 2025-04-27 23 26 16" src="https://github.com/user-attachments/assets/496fc086-3f9a-45ef-89bb-629bafdececd" />

[블로그](https://velog.io/@kny8092/Github-Action-PM2-%EB%B0%B0%ED%8F%AC%EC%8B%9C-pm2-command-not-found)에서 해결방법을 찾아 테스트해보려고 한다.