### PR TITLE
[develop] cd 워크플로의 잘못된 pm2 명령어 수정

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,4 +28,4 @@ jobs:
             source ~/.nvm/nvm.sh
             npm ci
             npm run build
-            pm2 gracefulReload hoyogg
+            pm2 reload hoyogg


### PR DESCRIPTION
#6 작업 이후 main 브랜치 push 테스트 결과 next build 이후 pm2 명령어에서 에러가 발생해 실패하는 것을 확인.

<img width="1100" alt="스크린샷 2025-04-27 23 35 56" src="https://github.com/user-attachments/assets/4b05ed49-99d4-46cc-b82f-d71b352a0144" />

GPT 할루시네이션(...)에 당해 gracefulReload커맨드가 존재하는 줄 알았다. 기존에 쓰던 `reload`로 교체했다.