### PR TITLE
[55/feat/character-detail-page] 캐릭터 상세 페이지 공통 컴포넌트/스토리북 구현

### DIFF
--- a/src/components/ArticleCard/ArticleCard.stories.tsx
+++ b/src/components/ArticleCard/ArticleCard.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { ArticleCard } from './ArticleCard';
+
+const meta = {
+  title: 'Components/Common/ArticleCard',
+  component: ArticleCard,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ArticleCard>;
+
+export default meta;
+
+export const TwoColumnLayout = (() => {
+  return (
+    <ArticleCard title="2열 그리드 레이아웃">
+      <ArticleCard.Grid>
+        <ArticleCard.Item label="생일" value="6월 1일" />
+        <ArticleCard.Item label="출시일" value="2020-09-28" />
+        <ArticleCard.Item label="소속" value="몬드" />
+        <ArticleCard.Item label="별자리" value="바람꽃자리" />
+      </ArticleCard.Grid>
+    </ArticleCard>
+  );
+}) satisfies StoryFn<typeof ArticleCard>;
+
+export const ThreeColumnLayout = (() => {
+  return (
+    <ArticleCard title="3열 그리드 레이아웃">
+      <ArticleCard.Grid columns={3}>
+        <ArticleCard.Item label="원소" value="바람" />
+        <ArticleCard.Item label="무기" value="한손검" />
+        <ArticleCard.Item label="레어도" value="5성" />
+        <ArticleCard.Item label="HP" value="12,981" />
+        <ArticleCard.Item label="공격력" value="335" />
+        <ArticleCard.Item label="방어력" value="784" />
+      </ArticleCard.Grid>
+    </ArticleCard>
+  );
+}) satisfies StoryFn<typeof ArticleCard>;
+
+export const HorizontalItemLayout = (() => {
+  return (
+    <ArticleCard title="가로 아이템 레이아웃">
+      <ArticleCard.Grid>
+        <ArticleCard.Item horizontal label="한국어" value="김하루" />
+        <ArticleCard.Item horizontal label="일본어" value="사이토 치와" />
+        <ArticleCard.Item horizontal label="영어" value="Stephanie Southerland" />
+        <ArticleCard.Item horizontal label="중국어" value="펑리야오" />
+      </ArticleCard.Grid>
+    </ArticleCard>
+  );
+}) satisfies StoryFn<typeof ArticleCard>;

--- a/src/components/ArticleCard/ArticleCard.stories.tsx
+++ b/src/components/ArticleCard/ArticleCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react';
-import { ArticleCard } from './ArticleCard';
+import ArticleCard from './ArticleCard';
 
 const meta = {
   title: 'Components/Common/ArticleCard',

--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -1,0 +1,8 @@
+import { ArticleCardGrid } from './ArticleCardGrid';
+import { ArticleCardItem } from './ArticleCardItem';
+import { ArticleCardWrapper } from './ArticleCardWrapper';
+
+export const ArticleCard = Object.assign(ArticleCardWrapper, {
+  Grid: ArticleCardGrid,
+  Item: ArticleCardItem,
+});

--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -1,8 +1,10 @@
-import { ArticleCardGrid } from './ArticleCardGrid';
-import { ArticleCardItem } from './ArticleCardItem';
-import { ArticleCardWrapper } from './ArticleCardWrapper';
+import ArticleCardGrid from './ArticleCardGrid';
+import ArticleCardItem from './ArticleCardItem';
+import ArticleCardWrapper from './ArticleCardWrapper';
 
-export const ArticleCard = Object.assign(ArticleCardWrapper, {
+const ArticleCard = Object.assign(ArticleCardWrapper, {
   Grid: ArticleCardGrid,
   Item: ArticleCardItem,
 });
+
+export default ArticleCard;

--- a/src/components/ArticleCard/ArticleCardGrid.tsx
+++ b/src/components/ArticleCard/ArticleCardGrid.tsx
@@ -1,0 +1,26 @@
+import { mediaQuery } from '@/styles/theme';
+import styled from '@emotion/styled';
+import type { HTMLAttributes } from 'react';
+
+type Props = HTMLAttributes<HTMLUListElement> & {
+  columns?: number;
+};
+
+export const ArticleCardGrid = ({ columns = 2, children, ...props }: Props) => {
+  return (
+    <StyledGrid $columns={columns} {...props}>
+      {children}
+    </StyledGrid>
+  );
+};
+
+const StyledGrid = styled.ul<{ $columns: number }>`
+  display: grid;
+  grid-template-columns: ${({ $columns }) => `repeat(${$columns}, 1fr)`};
+  gap: 16px;
+
+  ${mediaQuery.max768} {
+    grid-template-columns: ${({ $columns }) => `repeat(${$columns - 1}, 1fr)`};
+    gap: 12px;
+  }
+`;

--- a/src/components/ArticleCard/ArticleCardGrid.tsx
+++ b/src/components/ArticleCard/ArticleCardGrid.tsx
@@ -6,13 +6,13 @@ type Props = HTMLAttributes<HTMLUListElement> & {
   columns?: number;
 };
 
-export const ArticleCardGrid = ({ columns = 2, children, ...props }: Props) => {
+export default function ArticleCardGrid({ columns = 2, children, ...props }: Props) {
   return (
     <StyledGrid $columns={columns} {...props}>
       {children}
     </StyledGrid>
   );
-};
+}
 
 const StyledGrid = styled.ul<{ $columns: number }>`
   display: grid;

--- a/src/components/ArticleCard/ArticleCardItem.tsx
+++ b/src/components/ArticleCard/ArticleCardItem.tsx
@@ -7,14 +7,14 @@ type Props = HTMLAttributes<HTMLLIElement> & {
   value: string;
 };
 
-export const ArticleCardItem = ({ horizontal = false, label, value, ...props }: Props) => {
+export default function ArticleCardItem({ horizontal = false, label, value, ...props }: Props) {
   return (
     <StyledListItem $horizontal={horizontal} {...props}>
       <StyledLabel $horizontal={horizontal}>{label}</StyledLabel>
       <StyledValue>{value}</StyledValue>
     </StyledListItem>
   );
-};
+}
 
 const StyledListItem = styled.li<{ $horizontal: boolean }>`
   display: flex;

--- a/src/components/ArticleCard/ArticleCardItem.tsx
+++ b/src/components/ArticleCard/ArticleCardItem.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import type { HTMLAttributes } from 'react';
+
+type Props = HTMLAttributes<HTMLLIElement> & {
+  horizontal?: boolean;
+  label: string;
+  value: string;
+};
+
+export const ArticleCardItem = ({ horizontal = false, label, value, ...props }: Props) => {
+  return (
+    <StyledListItem $horizontal={horizontal} {...props}>
+      <StyledLabel $horizontal={horizontal}>{label}</StyledLabel>
+      <StyledValue>{value}</StyledValue>
+    </StyledListItem>
+  );
+};
+
+const StyledListItem = styled.li<{ $horizontal: boolean }>`
+  display: flex;
+  flex-direction: ${({ $horizontal }) => ($horizontal ? 'row' : 'column')};
+  align-items: ${({ $horizontal }) => ($horizontal ? 'center' : 'flex-start')};
+  gap: ${({ $horizontal }) => ($horizontal ? 8 : 4)}px;
+`;
+
+const StyledLabel = styled.p<{ $horizontal: boolean }>`
+  font-size: ${({ $horizontal }) => ($horizontal ? 15 : 11)}px;
+  font-weight: 500;
+  color: #7f7f8f;
+`;
+
+const StyledValue = styled.p`
+  font-size: 15px;
+  font-weight: 500;
+  color: #d0d0d8;
+`;

--- a/src/components/ArticleCard/ArticleCardWrapper.tsx
+++ b/src/components/ArticleCard/ArticleCardWrapper.tsx
@@ -6,14 +6,14 @@ type Props = HTMLAttributes<HTMLElement> & {
   title: string;
 };
 
-export const ArticleCardWrapper = ({ title, children, ...props }: Props) => {
+export default function ArticleCardWrapper({ title, children, ...props }: Props) {
   return (
     <StyledArticle {...props}>
       <Title>{title}</Title>
       {children}
     </StyledArticle>
   );
-};
+}
 
 const StyledArticle = styled.article`
   padding-block: 16px;

--- a/src/components/ArticleCard/ArticleCardWrapper.tsx
+++ b/src/components/ArticleCard/ArticleCardWrapper.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import type { HTMLAttributes } from 'react';
+import { mediaQuery } from '@/styles/theme';
+
+type Props = HTMLAttributes<HTMLElement> & {
+  title: string;
+};
+
+export const ArticleCardWrapper = ({ title, children, ...props }: Props) => {
+  return (
+    <StyledArticle {...props}>
+      <Title>{title}</Title>
+      {children}
+    </StyledArticle>
+  );
+};
+
+const StyledArticle = styled.article`
+  padding-block: 16px;
+  margin-bottom: 20px;
+`;
+
+const Title = styled.h2`
+  font-size: 18px;
+  font-weight: 600;
+  color: #d0d0d8;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #2a2a3f;
+
+  ${mediaQuery.max768} {
+    font-size: 16px;
+    margin-bottom: 14px;
+  }
+`;

--- a/src/features/genshin/containers/GenshinCharacterDetailContainer.tsx
+++ b/src/features/genshin/containers/GenshinCharacterDetailContainer.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { MAX_WIDTH } from '@/styles/layout';
 import { mediaQuery } from '@/styles/theme';
-import { ArticleCard } from '@/components/ArticleCard/ArticleCard';
+import ArticleCard from '@/components/ArticleCard/ArticleCard';
 import { useGetGenshinCharacterDetail } from '../hooks/queries/useGetGenshinCharacterDetail';
 import { useGenshinNameAndId } from '../hooks/useGenshinNameAndId';
 import { getGenshinAvatarUrl, getGenshinRank } from '../utils';

--- a/src/features/genshin/containers/GenshinCharacterDetailContainer.tsx
+++ b/src/features/genshin/containers/GenshinCharacterDetailContainer.tsx
@@ -1,9 +1,12 @@
 import styled from '@emotion/styled';
+import { MAX_WIDTH } from '@/styles/layout';
+import { mediaQuery } from '@/styles/theme';
+import { ArticleCard } from '@/components/ArticleCard/ArticleCard';
 import { useGetGenshinCharacterDetail } from '../hooks/queries/useGetGenshinCharacterDetail';
 import { useGenshinNameAndId } from '../hooks/useGenshinNameAndId';
 import { getGenshinAvatarUrl, getGenshinRank } from '../utils';
 import { CharacterCardWrapper } from '../components/CharacterCardWrapper/CharacterCardWrapper';
-import { MAX_WIDTH } from '@/styles/layout';
+import { elementTextMap, weaponTextMap } from '../constants';
 
 export default function GenshinCharacterDetailContainer() {
   const { id } = useGenshinNameAndId();
@@ -13,16 +16,71 @@ export default function GenshinCharacterDetailContainer() {
 
   return (
     <Wrapper>
-      <CharacterCardWrapper
-        name={characterDetail.Name}
-        title={characterDetail.CharaInfo.Title}
-        description={characterDetail.Desc}
-        rank={getGenshinRank(characterDetail.Rarity)}
-        element={characterDetail.Element}
-        region={characterDetail.CharaInfo.Region}
-        image={getGenshinAvatarUrl(characterDetail.Icon)}
-      />
-      <TodoText>추후 구현 예정입니다.</TodoText>
+      <TopSection>
+        <CharacterCardWrapper
+          name={characterDetail.Name}
+          title={characterDetail.CharaInfo.Title}
+          description={characterDetail.Desc}
+          rank={getGenshinRank(characterDetail.Rarity)}
+          element={characterDetail.Element}
+          region={characterDetail.CharaInfo.Region}
+          image={getGenshinAvatarUrl(characterDetail.Icon)}
+        />
+        <BasicInfoSection>
+          {/* Todo: 관심사에 따라 컴포넌트로 쪼개 리팩토링 */}
+          <ArticleCard title="기본 정보">
+            <ArticleCard.Grid>
+              <ArticleCard.Item label="원소" value={elementTextMap[characterDetail.Element]} />
+              <ArticleCard.Item label="무기" value={weaponTextMap[characterDetail.Weapon]} />
+              <ArticleCard.Item label="운명의 자리" value={characterDetail.CharaInfo.Constellation} />
+              <ArticleCard.Item label="소속" value={characterDetail.CharaInfo.Native} />
+              <ArticleCard.Item
+                label="생일"
+                value={`${characterDetail.CharaInfo.Birth[0]}월 ${characterDetail.CharaInfo.Birth[1]}일`}
+              />
+              <ArticleCard.Item label="출시일" value={characterDetail.CharaInfo.ReleaseDate.split(' ')[0]} />
+            </ArticleCard.Grid>
+          </ArticleCard>
+          {/* Todo: 관심사에 따라 컴포넌트로 쪼개 리팩토링 */}
+          <ArticleCard title="성우 정보">
+            <ArticleCard.Grid>
+              <ArticleCard.Item horizontal label="🇰🇷" value={characterDetail.CharaInfo.VA.Korean} />
+              <ArticleCard.Item horizontal label="🇯🇵" value={characterDetail.CharaInfo.VA.Japanese} />
+              <ArticleCard.Item horizontal label="🇨🇳" value={characterDetail.CharaInfo.VA.Chinese} />
+              <ArticleCard.Item horizontal label="🇺🇸" value={characterDetail.CharaInfo.VA.English} />
+            </ArticleCard.Grid>
+          </ArticleCard>
+        </BasicInfoSection>
+      </TopSection>
+      {/* Todo: 관심사에 따라 컴포넌트로 쪼개 리팩토링 */}
+      <ArticleCard title="기본 스텟">
+        <ArticleCard.Grid columns={3}>
+          <ArticleCard.Item label="HP" value={characterDetail.BaseHP.toLocaleString()} />
+          <ArticleCard.Item label="ATK" value={characterDetail.BaseATK.toLocaleString()} />
+          <ArticleCard.Item label="DEF" value={characterDetail.BaseDEF.toLocaleString()} />
+          <ArticleCard.Item label="치명타 확률" value={`${characterDetail.CritRate}%`} />
+          <ArticleCard.Item label="치명타 피해" value={`${characterDetail.CritDMG}%`} />
+          <ArticleCard.Item label="원소 마스터리" value={characterDetail.ElementalMastery.toLocaleString()} />
+        </ArticleCard.Grid>
+      </ArticleCard>
+      <ArticleCard title="전투 특성">
+        <Placeholder>(추후 구현 예정입니다.)</Placeholder>
+      </ArticleCard>
+      <ArticleCard title="고유 특성">
+        <Placeholder>(추후 구현 예정입니다.)</Placeholder>
+      </ArticleCard>
+      <ArticleCard title="운명의 자리">
+        <Placeholder>(추후 구현 예정입니다.)</Placeholder>
+      </ArticleCard>
+      <ArticleCard title="육성 재료">
+        <Placeholder>(추후 구현 예정입니다.)</Placeholder>
+      </ArticleCard>
+      <ArticleCard title="기타 정보">
+        <Placeholder>(추후 구현 예정입니다.)</Placeholder>
+      </ArticleCard>
+      <ArticleCard title="스토리 & 대사">
+        <Placeholder>(추후 구현 예정입니다.)</Placeholder>
+      </ArticleCard>
     </Wrapper>
   );
 }
@@ -31,12 +89,37 @@ const Wrapper = styled.section`
   width: 100%;
   max-width: ${MAX_WIDTH};
   margin: 0 auto;
-  padding: 0 0 20px 0;
+  padding: 10px 20px;
   background-color: rgb(30, 30, 47);
+
+  ${mediaQuery.max768} {
+    padding: 12px;
+  }
 `;
 
-const TodoText = styled.h2`
-  font-weight: 600;
-  font-size: 32px;
-  color: #eee;
+const TopSection = styled.div`
+  display: flex;
+  gap: 30px;
+
+  ${mediaQuery.max768} {
+    flex-direction: column;
+    gap: 0;
+  }
+`;
+
+const BasicInfoSection = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`;
+
+// Placeholder
+const Placeholder = styled.div`
+  padding: 40px;
+  text-align: center;
+  color: #6f6f7f;
+  font-size: 13px;
+  background-color: transparent;
+  border-radius: 15px;
+  border: 1px dashed #2a2a3f;
 `;


### PR DESCRIPTION
## ✨ 작업한 내용

공통 컴포넌트 작업 후, 테스트를 위해 캐릭터 기본 정보와 성우 데이터를 렌더링 했습니다. (#55)

- [x] 캐릭터 상세 페이지에서 사용할 공통 컴포넌트 구현 (`ArticleCard`: 합성 컴포넌트 구조)
- [x] 공통 컴포넌트에 대한 스토리북 예시 추가
- [x] 캐릭터 기본 정보, 성우 정보 영역 퍼블리싱 (컴포넌트 분리 추후 진행 예정)

## 📷스크린샷 / 영상

| StoryBook | 캐릭터 상세 페이지 |
|-----------|---------------|
| <img width="947" height="966" alt="스크린샷 2025-11-02 21 22 09" src="https://github.com/user-attachments/assets/02033c97-3ee8-4842-8e60-0f65a5474c3e" /> | <img width="1358" height="1025" alt="스크린샷 2025-11-02 21 21 23" src="https://github.com/user-attachments/assets/62b83374-df99-44fa-9f8e-1b2861e173ed" /> |
